### PR TITLE
Remove function names from bin && Remove LOG_FATAL

### DIFF
--- a/base/src/d3d/renderer.cpp
+++ b/base/src/d3d/renderer.cpp
@@ -24,7 +24,7 @@ namespace gta_base::d3d {
 
     void* device{};
     if (FAILED(swap_chain_->GetDevice(__uuidof(ID3D11Device), &device))) {
-      LOG_FATAL("Failed to get device from swap chain");
+      LOG_CRITICAL("Failed to get device from swap chain");
     }
     device_.Attach(static_cast<ID3D11Device*>(device));
     device_->GetImmediateContext(device_context_.GetAddressOf());

--- a/base/src/dllmain.cpp
+++ b/base/src/dllmain.cpp
@@ -28,7 +28,7 @@ BOOL WINAPI DllMain(HINSTANCE dll_handle, DWORD call_reason, LPVOID) {
       try {
         BaseMain();
       } catch (std::exception& e) {
-        LOG_FATAL(e.what());
+        LOG_CRITICAL(e.what());
       }
 
       LOG_INFO("Shutting logging down...");

--- a/base/src/fiber/script.cpp
+++ b/base/src/fiber/script.cpp
@@ -47,7 +47,7 @@ namespace gta_base::fiber {
       offset = ((DWORD64) e->ExceptionRecord->ExceptionAddress - (DWORD64) mod);
       GetModuleFileNameA(mod, buffer, MAX_PATH - 1);
     }
-    LOG_FATAL("Exception Code: 0x{} Exception Offset: 0x{} Fault Module Name: {}", e->ExceptionRecord->ExceptionCode, offset, buffer);
+    LOG_CRITICAL("Exception Code: 0x{} Exception Offset: 0x{} Fault Module Name: {}", e->ExceptionRecord->ExceptionCode, offset, buffer);
   }
 
   [[noreturn]] void Script::FiberFunc() {

--- a/base/src/hooking/hooking_helpers/detour.cpp
+++ b/base/src/hooking/hooking_helpers/detour.cpp
@@ -50,7 +50,7 @@ namespace gta_base::hooking {
     __except(ExpHandler(GetExceptionInformation(), name_))
     {
       [this]() {
-        LOG_FATAL("Failed to fix hook address for '{}'", name_);
+        LOG_CRITICAL("Failed to fix hook address for '{}'", name_);
       }();
     }
   }

--- a/base/src/hooking/hooking_helpers/vmt.cpp
+++ b/base/src/hooking/hooking_helpers/vmt.cpp
@@ -22,7 +22,7 @@ namespace gta_base::hooking {
     LPVOID og;
 
     if (auto status = MH_CreateHook(target, detour, &og); status != MH_OK) {
-      LOG_FATAL("Failed to create hook '{}' at 0x{:X} (error: {})", name, uintptr_t(target), MH_StatusToString(status));
+      LOG_CRITICAL("Failed to create hook '{}' at 0x{:X} (error: {})", name, uintptr_t(target), MH_StatusToString(status));
     }
 
     hooks_[index] = {name, target, detour, og};
@@ -33,7 +33,7 @@ namespace gta_base::hooking {
       LOG_WARN("Tried to remove hook at idx: {} which doesn't exist", index);
     } else {
       if (auto status = MH_RemoveHook(it->second.target); status != MH_OK) {
-        LOG_FATAL("Failed to remove hook at idx: {} with the name: {}", index, it->second.name);
+        LOG_CRITICAL("Failed to remove hook at idx: {} with the name: {}", index, it->second.name);
       }
 
       hooks_.erase(it);
@@ -45,7 +45,7 @@ namespace gta_base::hooking {
       LOG_WARN("Tried to enable hook at idx: {} which doesn't exist", index);
     } else {
       if (auto status = MH_EnableHook(it->second.target); status != MH_OK)
-        LOG_FATAL("Failed to enable hook at idx: {} with the name: {}", index, it->second.name);
+        LOG_CRITICAL("Failed to enable hook at idx: {} with the name: {}", index, it->second.name);
       else
         LOG_DEBUG("Enabled hook at idx: {} with the name: {} src -> {}, dst -> {}, og -> {}", index, it->second.name, it->second.target, it->second.detour, it->second.original);
     }
@@ -56,7 +56,7 @@ namespace gta_base::hooking {
       LOG_WARN("Tried to disable hook at idx: {} which doesn't exist", index);
     } else {
       if (auto status = MH_DisableHook(it->second.target); status != MH_OK) {
-        LOG_FATAL("Failed to disable hook at idx: {} with the name: {}", index, it->second.name);
+        LOG_CRITICAL("Failed to disable hook at idx: {} with the name: {}", index, it->second.name);
       }
     }
   }
@@ -78,7 +78,7 @@ namespace gta_base::hooking {
     __except(ExpHandler(GetExceptionInformation(), name))
     {
       [&name]() {
-        LOG_FATAL("Failed to fix hook address for '{}'", name);
+        LOG_CRITICAL("Failed to fix hook address for '{}'", name);
       }();
     }
   }

--- a/base/src/logger/logger.hpp
+++ b/base/src/logger/logger.hpp
@@ -36,6 +36,7 @@ namespace gta_base {
 
   public:
     Logger();
+
     ~Logger();
 
     void Flush();
@@ -53,17 +54,49 @@ namespace gta_base {
     void Shutdown();
 
     void SetupExceptionHandler();
+
     void RemoveExceptionHandler();
   };
 
   inline Logger* kLOGGER{};
 }
 
-#define LOG_TRACE(...) SPDLOG_TRACE(__VA_ARGS__)
-#define LOG_DEBUG(...) SPDLOG_DEBUG(__VA_ARGS__)
-#define LOG_INFO(...)  SPDLOG_INFO(__VA_ARGS__)
-#define LOG_WARN(...) SPDLOG_WARN(__VA_ARGS__)
-#define LOG_ERROR(...) SPDLOG_ERROR(__VA_ARGS__)
-#define LOG_CRITICAL(...) SPDLOG_CRITICAL(__VA_ARGS__)
-#define LOG_FATAL(...) SPDLOG_CRITICAL(__VA_ARGS__)
+#define LOGGER_LOG(logger, level, ...) (logger)->log(spdlog::source_loc{__FILE__, __LINE__, "redacted"}, level, __VA_ARGS__)
+
+#if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_TRACE
+#define LOG_TRACE(...) LOGGER_LOG(spdlog::default_logger_raw(), spdlog::level::trace, __VA_ARGS__)
+#else
+#define LOG_TRACE(...)  (void)0
+#endif
+
+#if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_DEBUG
+#define LOG_DEBUG(...) LOGGER_LOG(spdlog::default_logger_raw(), spdlog::level::debug, __VA_ARGS__)
+#else
+#define LOG_DEBUG(...)  (void)0
+#endif
+
+#if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_INFO
+#define LOG_INFO(...) LOGGER_LOG(spdlog::default_logger_raw(), spdlog::level::info, __VA_ARGS__)
+#else
+#define LOG_INFO(...)  (void)0
+#endif
+
+#if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_WARN
+#define LOG_WARN(...) LOGGER_LOG(spdlog::default_logger_raw(), spdlog::level::warn, __VA_ARGS__)
+#else
+#define LOG_WARN(...)  (void)0
+#endif
+
+#if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_ERROR
+#define LOG_ERROR(...) LOGGER_LOG(spdlog::default_logger_raw(), spdlog::level::err, __VA_ARGS__)
+#else
+#define LOG_ERROR(...)  (void)0
+#endif
+
+#if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_CRITICAL
+#define LOG_CRITICAL(...) LOGGER_LOG(spdlog::default_logger_raw(), spdlog::level::critical, __VA_ARGS__)
+#else
+#define LOG_CRITICAL(...)  (void)0
+#endif
+
 #endif //GTABASE_LOGGER_HPP

--- a/base/src/lua/script.cpp
+++ b/base/src/lua/script.cpp
@@ -141,7 +141,7 @@ namespace gta_base::lua {
     });
 
     logging_metatable.set_function("fatal", [&](const std::string& msg, sol::variadic_args va) {
-      LOG_FATAL("[{}:{}] {}", GetCurrentFile(lua_state_), GetCurrentLine(lua_state_), FormatLuaVariadicArgs(msg, va));
+      LOG_CRITICAL("[{}:{}] {}", GetCurrentFile(lua_state_), GetCurrentLine(lua_state_), FormatLuaVariadicArgs(msg, va));
     });
 
     logging_metatable.set_function("debug", [&](const std::string& msg, sol::variadic_args va) {


### PR DESCRIPTION
Remove all function names that got inserted into the binary when logging. The function names where not used but where all over the bin.

Also remove LOG_FATAL since this doesn't exist. And just outputs LOG_CRITICAL.