### PR TITLE
Fix code scanning alert #60

### DIFF
--- a/menu/src/ui/localization/manager.cpp
+++ b/menu/src/ui/localization/manager.cpp
@@ -40,7 +40,7 @@ namespace base::menu::ui::localization {
     Status Translation::Save(const std::string& name) {
         const auto ec = glz::write_file_json<glz::opts{.prettify = true}>(loaded_translation_, GetProfilePath(name), std::string{});
         if (ec) {
-            return MakeFailure<ResultCode::kIO_ERROR>(magic_enum::enum_name(ec.ec).data());
+            return MakeFailure<ResultCode::kIO_ERROR>(std::string(magic_enum::enum_name(ec.ec)));
         }
 
         return {};


### PR DESCRIPTION
This pull request includes a small change to the `menu/src/ui/localization/manager.cpp` file. The change modifies the `Save` method in the `Translation` class to improve how error messages are handled.

* [`menu/src/ui/localization/manager.cpp`](diffhunk://#diff-4a2936bb8a9392ae88662a53322e31007d667443d1777302055bf9d2eba33021L43-R43): Changed the `Save` method to convert the error code to a `std::string` using the `magic_enum::enum_name` function.