### PR TITLE
Exclude .idea folder from sonar

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,7 +7,7 @@ sonar.projectVersion=2.0
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=.
-sonar.exclusions=build/**/*,vendor/**/*,**/test/**/*
+sonar.exclusions=build/**/*,vendor/**/*,**/test/**/*,**/.idea/**/*
 sonar.tests=.
 sonar.test.inclusions=**/test/**/*
 


### PR DESCRIPTION
This pull request includes a minor update to the `sonar-project.properties` file. The change adds the `.idea` directory to the list of excluded paths for SonarQube analysis.

* [`sonar-project.properties`](diffhunk://#diff-43ed9d31bea2a6d518d69836bcd1a8e6bd81bf4df96c4745792c220ca5aa549cL10-R10): Added `**/.idea/**/*` to the `sonar.exclusions` to exclude IDE configuration files from the analysis.