### PR TITLE
Fix uncaught exception menu renderer imgui shutdown

### DIFF
--- a/menu/src/render/renderer.cpp
+++ b/menu/src/render/renderer.cpp
@@ -56,8 +56,10 @@ namespace base::menu::render {
 
     try {
       ShutdownImGui();
+    } catch (const std::exception& e) {
+      LOG_CRITICAL("Failed to shutdown ImGui: {}", e.what());
     } catch (...) {
-      LOG_CRITICAL("Failed to shutdown ImGui");
+      LOG_CRITICAL("Failed to shutdown ImGui due to an unknown error");
     }
   }
 

--- a/menu/src/render/renderer.cpp
+++ b/menu/src/render/renderer.cpp
@@ -54,7 +54,11 @@ namespace base::menu::render {
 
     font_mgr_inst_.reset();
 
-    ShutdownImGui();
+    try {
+      ShutdownImGui();
+    } catch (...) {
+      LOG_CRITICAL("Failed to shutdown ImGui");
+    }
   }
 
   HRESULT Renderer::Present(IDXGISwapChain* swap_chain, UINT sync_interval, UINT flags) {


### PR DESCRIPTION
This pull request includes an important change to improve the robustness of the `Renderer` class in the `menu/src/render/renderer.cpp` file. The change adds error handling to the `ShutdownImGui` function to log a critical error message if the shutdown process fails.

Error handling improvement:

* [`menu/src/render/renderer.cpp`](diffhunk://#diff-455db802802a72aebdabb2d6131f9181055415eb0afff43e11bc4b42817ada0cR57-R61): Wrapped the `ShutdownImGui` call in a try-catch block and added a critical log message in the catch block to handle potential exceptions during the shutdown process.