### PR TITLE
Remove the cache action for sonarcloud

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,14 +79,6 @@ jobs:
           key: ${{ runner.os }}-vendor-${{ matrix.build-config }}-${{ hashFiles('vendor/**/*.*') }}
           restore-keys: |
             ${{ runner.os }}-vendor-${{ matrix.build-config }}-
-      - name: Cache SonarCloud scanner
-        if: matrix.language == 'c-cpp'
-        uses: actions/cache@v4.2.3
-        with:
-          path: ${{ env.SONAR_USER_HOME }}
-          key: ${{ runner.os }}-sonar-${{ github.ref_name }}
-          restore-keys: |
-            ${{ runner.os }}-sonar-
 
       - name: Initialize CodeQL
         if: matrix.build-config == 'Debug'


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/build.yml` file, specifically removing the caching step for the SonarCloud scanner for C/C++ projects.

Changes in `jobs:`:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L82-L89): Removed the step that caches the SonarCloud scanner when the language is C/C++.