### PR TITLE
Improve CMake ci caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
         uses: actions/cache@v4.2.3
         with:
           path: ${{ env.BUILD_DIR }}
-          key: ${{ runner.os }}-cmake-${{ matrix.build-config }}-${{ hashFiles('CMakeLists.txt', 'src/**/CMakeLists.txt', 'injector/src/**/CMakeLists.txt', 'menu/src/**/CMakeLists.txt', 'vendor/**/*.cmake', 'src/**/*.cpp', 'src/**/*.hpp', 'injector/src/**/*.cpp', 'injector/src/**/*.hpp', 'menu/src/**/*.cpp', 'menu/src/**/*.hpp', '**/*.h', '**/*.asm') }}
+          key: ${{ runner.os }}-cmake-${{ matrix.build-config }}-${{ hashFiles('CMakeLists.txt', '**/CMakeLists.txt', '**/*.cmake', '**/*.cpp', '**/*.c', '**/*.hpp', '**/*.h', '**/*.asm') }}
           restore-keys: |
             ${{ runner.os }}-cmake-${{ matrix.build-config }}-
       - name: Cache vendor

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,7 @@ jobs:
 
       - name: Cache CMake build files
         if: matrix.language == 'c-cpp'
+        id: cache-cmake
         uses: actions/cache@v4.2.3
         with:
           path: ${{ env.BUILD_DIR }}
@@ -74,7 +75,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cmake-${{ matrix.build-config }}-
       - name: Cache vendor
-        if: matrix.language == 'c-cpp'
+        if: matrix.language == 'c-cpp' && steps.cache-cmake.outputs.cache-hit != 'true'
         uses: actions/cache@v4.2.3
         with:
           path: ${{ env.BUILD_DIR }}/_deps

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,13 +70,15 @@ jobs:
         uses: actions/cache@v4.2.3
         with:
           path: ${{ env.BUILD_DIR }}
-          key: ${{ runner.os }}-cmake-${{ matrix.build-config }}-${{ hashFiles('CMakeLists.txt', '**/CMakeLists.txt', '**/*.hpp', '**/*.cpp') }}
+          key: ${{ runner.os }}-cmake-${{ matrix.build-config }}-${{ hashFiles('CMakeLists.txt', 'src/**/CMakeLists.txt', 'injector/src/**/CMakeLists.txt', 'menu/src/**/CMakeLists.txt', 'vendor/**/*.cmake', 'src/**/*.cpp', 'src/**/*.hpp', 'injector/src/**/*.cpp', 'injector/src/**/*.hpp', 'menu/src/**/*.cpp', 'menu/src/**/*.hpp', '**/*.h', '**/*.asm') }}
+          restore-keys: |
+            ${{ runner.os }}-cmake-${{ matrix.build-config }}-
       - name: Cache vendor
         if: matrix.language == 'c-cpp'
         uses: actions/cache@v4.2.3
         with:
           path: ${{ env.BUILD_DIR }}/_deps
-          key: ${{ runner.os }}-vendor-${{ matrix.build-config }}-${{ hashFiles('vendor/**/*.*') }}
+          key: ${{ runner.os }}-vendor-${{ matrix.build-config }}-${{ hashFiles('**/vendor/**/*.cmake') }}
           restore-keys: |
             ${{ runner.os }}-vendor-${{ matrix.build-config }}-
       - name: Cache SonarCloud scanner

--- a/build.bat
+++ b/build.bat
@@ -1,2 +1,0 @@
-cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-cmake --build build/ --config Release

--- a/menu/src/render/renderer.cpp
+++ b/menu/src/render/renderer.cpp
@@ -54,7 +54,13 @@ namespace base::menu::render {
 
     font_mgr_inst_.reset();
 
-    ShutdownImGui();
+    try {
+      ShutdownImGui();
+    } catch (const std::exception& e) {
+      LOG_CRITICAL("Failed to shutdown ImGui: {}", e.what());
+    } catch (...) {
+      LOG_CRITICAL("Failed to shutdown ImGui due to an unknown error");
+    }
   }
 
   HRESULT Renderer::Present(IDXGISwapChain* swap_chain, UINT sync_interval, UINT flags) {


### PR DESCRIPTION
This pull request includes updates to the build process configuration files to improve caching efficiency and remove unused commands.

Improvements to caching in GitHub Actions workflow:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R70-R82): Added `id: cache-cmake` to the CMake cache step, expanded the `key` to include more file patterns, and added `restore-keys` for better cache retrieval. Also, updated the vendor cache step to check if the CMake cache was a hit before proceeding.

Removal of unused commands:

* [`build.bat`](diffhunk://#diff-0e537793becf5cb1e60d7206d4b877f6e7f2276602f6fed815161e265fafa269L1-L2): Removed outdated CMake build commands to clean up the build script.