### PR TITLE
Fix deps being scanned

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,6 +158,7 @@ jobs:
           output: ${{ github.workspace }}/results/codeql/cpp.sarif
           patterns: |
             -build/**
+            -.vendor/**
       - name: Upload CodeQL SARIF
         if: matrix.build-config == 'Debug'
         uses: github/codeql-action/upload-sarif@v3

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,7 +7,7 @@ sonar.projectVersion=2.0
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=.
-sonar.exclusions=build/**/*,vendor/**/*,**/test/**/*,**/.idea/**/*
+sonar.exclusions=build/**/*,**/test/**/*,**/.idea/**/*,**/.vendor/**/*
 sonar.tests=.
 sonar.test.inclusions=**/test/**/*
 


### PR DESCRIPTION
This pull request includes updates to exclude the `.vendor` directory from code analysis tools. The changes ensure that files within `.vendor` are not included in the CodeQL SARIF upload or SonarQube analysis.

### Code analysis exclusions:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R161): Updated the `patterns` section to exclude the `.vendor` directory from CodeQL SARIF analysis.
* [`sonar-project.properties`](diffhunk://#diff-43ed9d31bea2a6d518d69836bcd1a8e6bd81bf4df96c4745792c220ca5aa549cL10-R10): Added `.vendor` to the `sonar.exclusions` property to exclude it from SonarQube analysis.