### PR TITLE
Fix path for build artifacts in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,6 +181,7 @@ jobs:
         with:
           name: build-artifacts-${{ matrix.build-config }}
           path: |
-            ${{ env.BUILD_DIR }}/**/${{ matrix.build-config }}/**/*.exe
-            ${{ env.BUILD_DIR }}/**/${{ matrix.build-config }}/**/*.dll
+            ${{ env.BUILD_DIR }}/**/menu_bin/**/*.exe
+            ${{ env.BUILD_DIR }}/**/menu_bin/**/*.dll
+            ${{ env.BUILD_DIR }}/**/menu_bin/**/*.pdb
           retention-days: 7


### PR DESCRIPTION
This pull request updates the artifact paths in the `build.yml` workflow file to reflect changes in the directory structure and include additional file types.

Workflow configuration updates:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L184-R186): Changed artifact paths from `${{ env.BUILD_DIR }}/**/${{ matrix.build-config }}` to `${{ env.BUILD_DIR }}/**/menu_bin`, and added support for `.pdb` files alongside `.exe` and `.dll`.