### PR TITLE
Make the injector use less cpu

### DIFF
--- a/common/src/logging/logger.cpp
+++ b/common/src/logging/logger.cpp
@@ -68,10 +68,16 @@ namespace base::common::logging {
 
     void MovePossibleCrashLog() {
       const auto log_file_path = GetLogFile();
-      if (std::filesystem::exists(log_file_path)) {
-        const auto log_file_path_tmp = log_file_path.parent_path() / fmt::format("{}_{}_hard_crash{}", util::time::GetTimeStamp(), log_file_path.stem().string(), log_file_path.extension().string());
-        std::filesystem::rename(log_file_path, log_file_path_tmp);
-        SaveLogFile(log_file_path_tmp);
+      try {
+        if (std::filesystem::exists(log_file_path)) {
+          const auto log_file_path_tmp = log_file_path.parent_path() / fmt::format("{}_{}_hard_crash{}", util::time::GetTimeStamp(), log_file_path.stem().string(), log_file_path.extension().string());
+          std::filesystem::rename(log_file_path, log_file_path_tmp);
+          SaveLogFile(log_file_path_tmp);
+        }
+      } catch (std::filesystem::filesystem_error& e) {
+        MessageBoxA(nullptr, fmt::format("{}\n{}\n{}", e.what(), e.path1().string(), e.path2().string()).c_str(), "exception while moving log file", MB_OK | MB_ICONERROR | MB_SYSTEMMODAL);
+      } catch (...) {
+        MessageBoxA(nullptr, xorstr_("An unknown error occurred while moving the log file."), xorstr_("Critical logging error"), MB_OK | MB_ICONERROR | MB_SYSTEMMODAL);
       }
     }
 

--- a/common/src/logging/logger.cpp
+++ b/common/src/logging/logger.cpp
@@ -74,7 +74,7 @@ namespace base::common::logging {
           std::filesystem::rename(log_file_path, log_file_path_tmp);
           SaveLogFile(log_file_path_tmp);
         }
-      } catch (std::filesystem::filesystem_error& e) {
+      } catch (const std::filesystem::filesystem_error& e) {
         MessageBoxA(nullptr, fmt::format("{}\n{}\n{}", e.what(), e.path1().string(), e.path2().string()).c_str(), "exception while moving log file", MB_OK | MB_ICONERROR | MB_SYSTEMMODAL);
       } catch (...) {
         MessageBoxA(nullptr, xorstr_("An unknown error occurred while moving the log file."), xorstr_("Critical logging error"), MB_OK | MB_ICONERROR | MB_SYSTEMMODAL);

--- a/injector/src/main.cpp
+++ b/injector/src/main.cpp
@@ -129,7 +129,7 @@ std::int32_t APIENTRY WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 
   const Window window(kWINDOW_WIDTH, kWINDOW_HEIGHT);
 
-  std::thread thread(GameRunningChecker);
+  std::thread game_running_check_thread(GameRunningChecker);
 
   // init to initial values
   strncpy_s(dll_path.get(), MAX_PATH, kSETTINGS.dll_path.c_str(), _TRUNCATE);
@@ -156,6 +156,10 @@ std::int32_t APIENTRY WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
     }
 
     std::this_thread::yield();
+  }
+
+  if (game_running_check_thread.joinable()) {
+    game_running_check_thread.join();
   }
 
   return 0;

--- a/injector/src/main.cpp
+++ b/injector/src/main.cpp
@@ -53,7 +53,7 @@ void DoFrame(const base::injector::Window& window) {
     if (ImGui::Begin("Injector window", nullptr, ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize)) {
       if (ImGui::BeginTabBar("tabs")) {
         if (ImGui::BeginTabItem("Injector")) {
-          ImGui::Text((!kGAME_RUNNING ? "Game not running" : fmt::format("Game running: {}", kGAME_RUNNING ? "yes" : "no")).c_str());
+          ImGui::Text(!kGAME_RUNNING ? "Game not running" : "Game running");
           if (kGAME_RUNNING) {
             if (ImGui::Button("Inject")) {
               auto _ = std::async(std::launch::async, []() {


### PR DESCRIPTION
This pull request introduces error handling improvements in the logging module and adds a new thread-based mechanism to monitor the game's running state in the injector module. These changes enhance robustness and usability.

### Error handling improvements in logging:
* Added `try-catch` blocks in `MovePossibleCrashLog` to handle `std::filesystem::filesystem_error` and unknown exceptions. Errors are reported via message boxes for better debugging and user feedback (`common/src/logging/logger.cpp`, [common/src/logging/logger.cppR71-R81](diffhunk://#diff-5aadfa28f4d6694599556fc16c98b80add180b8c597607c44b2b3979144549f4R71-R81)).

### Game state monitoring in the injector:
* Introduced a new `std::atomic_bool` variable `kGAME_RUNNING` to track the game's running state (`injector/src/main.cpp`, [injector/src/main.cppL15-R16](diffhunk://#diff-3182e0b67c7bb3aa9ede72e2630e3ee95cb86213c049751bc84a9e418ec8633cL15-R16)).
* Added a `GameRunningChecker` function running in a separate thread to periodically check if the game is running and update `kGAME_RUNNING` accordingly (`injector/src/main.cpp`, [[1]](diffhunk://#diff-3182e0b67c7bb3aa9ede72e2630e3ee95cb86213c049751bc84a9e418ec8633cL39-R60) [[2]](diffhunk://#diff-3182e0b67c7bb3aa9ede72e2630e3ee95cb86213c049751bc84a9e418ec8633cR132-R133).
* Updated the `DoFrame` function to use `kGAME_RUNNING` for displaying game status and handling injection logic, improving clarity and separation of concerns (`injector/src/main.cpp`, [injector/src/main.cppL39-R60](diffhunk://#diff-3182e0b67c7bb3aa9ede72e2630e3ee95cb86213c049751bc84a9e418ec8633cL39-R60)).
* Added `std::this_thread::yield()` in the main loop to reduce CPU usage when idle (`injector/src/main.cpp`, [injector/src/main.cppR157-R158](diffhunk://#diff-3182e0b67c7bb3aa9ede72e2630e3ee95cb86213c049751bc84a9e418ec8633cR157-R158)).